### PR TITLE
fix: ensure the registry name is in lowercase

### DIFF
--- a/requirements.tf
+++ b/requirements.tf
@@ -1,7 +1,7 @@
 locals {
   jx_requirements_interpolated_content = templatefile("${path.module}/jx-requirements.yml.tpl", {
 
-    registry_name        = "${module.registry.registry_name}.azurecr.io"
+    registry_name        = lower("${module.registry.registry_name}.azurecr.io")
     domain               = module.dns.domain
     apex_domain          = var.apex_domain
     subdomain            = var.subdomain


### PR DESCRIPTION
See https://docs.microsoft.com/en-us/azure/container-registry/container-registry-faq#az-acr-login-succeeds-but-docker-fails-with-error-unauthorized-authentication-required

> az acr login succeeds but docker fails with error: unauthorized: authentication required

> Make sure you use an all lowercase server URL, for example, docker push myregistry.azurecr.io/myimage:latest, even if the registry resource name is uppercase or mixed case, like myRegistry.

`jx gitops variables` also need to be fixed, PR incoming...