### PR TITLE
Add ability to use existing ACR

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -67,10 +67,12 @@ module "cluster" {
 }
 
 module "registry" {
-  source       = "./terraform-jx-registry-acr"
-  cluster_name = local.cluster_name
-  principal_id = module.cluster.kubelet_identity_id
-  location     = var.location
+  source                               = "./terraform-jx-registry-acr"
+  cluster_name                         = local.cluster_name
+  principal_id                         = module.cluster.kubelet_identity_id
+  location                             = var.location
+  use_existing_acr_name                = var.use_existing_acr_name
+  use_existing_acr_resource_group_name = var.use_existing_acr_resource_group_name
 }
 
 module "jx-boot" {

--- a/terraform-jx-registry-acr/main.tf
+++ b/terraform-jx-registry-acr/main.tf
@@ -12,26 +12,37 @@ terraform {
 }
 
 resource "azurerm_resource_group" "acr" {
+  count = var.use_existing_acr_name == null ? 1 : 0
+
   name     = local.resource_group_name
   location = var.location
 }
 
 resource "azurerm_container_registry" "acr" {
+  count = var.use_existing_acr_name == null ? 1 : 0
+
   name                = local.container_registry_name
-  resource_group_name = azurerm_resource_group.acr.name
+  resource_group_name = azurerm_resource_group.acr[0].name
   location            = var.location
   sku                 = "Basic"
   admin_enabled       = true
 }
 
+data "azurerm_container_registry" "acr_existing" {
+  count = var.use_existing_acr_name == null ? 0 : 1
+
+  name                = var.use_existing_acr_name
+  resource_group_name = var.use_existing_acr_resource_group_name
+}
+
 resource "azurerm_role_assignment" "acrpull" {
-  scope                = azurerm_container_registry.acr.id
+  scope                = var.use_existing_acr_name == null ? azurerm_container_registry.acr[0].id : data.azurerm_container_registry.acr_existing[0].id
   role_definition_name = "AcrPull"
   principal_id         = var.principal_id
 }
 
 resource "azurerm_role_assignment" "acrpush" {
-  scope                = azurerm_container_registry.acr.id
+  scope                = var.use_existing_acr_name == null ? azurerm_container_registry.acr[0].id : data.azurerm_container_registry.acr_existing[0].id
   role_definition_name = "AcrPush"
   principal_id         = var.principal_id
 }

--- a/terraform-jx-registry-acr/outputs.tf
+++ b/terraform-jx-registry-acr/outputs.tf
@@ -1,9 +1,9 @@
 output "registry_name" {
-  value = azurerm_container_registry.acr.name
+  value = var.use_existing_acr_name == null ? azurerm_container_registry.acr[0].name : data.azurerm_container_registry.acr_existing[0].name
 }
 output "admin_username" {
-  value = azurerm_container_registry.acr.admin_username
+  value = var.use_existing_acr_name == null ? azurerm_container_registry.acr[0].admin_username : data.azurerm_container_registry.acr_existing[0].admin_username
 }
 output "admin_password" {
-  value = azurerm_container_registry.acr.admin_password
+  value = var.use_existing_acr_name == null ? azurerm_container_registry.acr[0].admin_password : data.azurerm_container_registry.acr_existing[0].admin_password
 }

--- a/terraform-jx-registry-acr/variables.tf
+++ b/terraform-jx-registry-acr/variables.tf
@@ -21,3 +21,15 @@ variable "principal_id" {
   description = "Principal id of the identity to give authorisation to push/pull to container registry"
   type        = string
 }
+
+variable "use_existing_acr_name" {
+  description = "Name of the existing ACR that you would like to use, e.g. use this in multicluster setup, when you want to use DEV cluster ACR."
+  type        = string
+  default     = null
+}
+
+variable "use_existing_acr_resource_group_name" {
+  description = "Name of the resources group of the existing ACR that you would like to use, e.g. use this in multicluster setup, when you want to use DEV cluster ACR."
+  type        = string
+  default     = null
+}

--- a/variables.tf
+++ b/variables.tf
@@ -171,6 +171,22 @@ variable "key_vault_sku" {
   default     = "standard"
 }
 
+// ----------------------------------------------------------------------------
+// Registry variables
+// ---------------------------------------------------------------------------
+variable "use_existing_acr_name" {
+  description = "Name of the existing ACR that you would like to use, e.g. use this in multicluster setup, when you want to use DEV cluster ACR."
+  type        = string
+  default     = null
+}
+
+variable "use_existing_acr_resource_group_name" {
+  description = "Name of the resources group of the existing ACR that you would like to use, e.g. use this in multicluster setup, when you want to use DEV cluster ACR."
+  type        = string
+  default     = null
+}
+
+
 
 // ----------------------------------------------------------------------------
 // Storage variables


### PR DESCRIPTION
Add support to specify custom ACR, that you already created and want to use in your cluster. Common usecase could be, that you would like to create a multicluster setup, so in the production cluster you would like to use existing DEV cluster ACR.