### PR TITLE
chore: update k8s version to a supported one

### DIFF
--- a/terraform-jx-cluster-aks/variables.tf
+++ b/terraform-jx-cluster-aks/variables.tf
@@ -16,7 +16,7 @@ variable "dns_prefix" {
 }
 variable "cluster_version" {
   type    = string
-  default = "1.18.10"
+  default = "1.20.7"
 }
 variable "location" {
   type    = string

--- a/variables.tf
+++ b/variables.tf
@@ -47,7 +47,7 @@ variable "dns_prefix" {
 }
 variable "cluster_version" {
   type        = string
-  default     = "1.18.10"
+  default     = "1.20.7"
   description = "Kubernetes version to use for the AKS cluster"
 }
 variable "network_resource_group_name" {


### PR DESCRIPTION
1.18.10 is not currently supported by Azure
```
➜  terraform-jx-azure (main) az aks get-versions --location uksouth --output table                                                                            ✭

KubernetesVersion    Upgrades
-------------------  ------------------------
1.21.1(preview)      None available
1.20.7               1.21.1(preview)
1.20.5               1.20.7, 1.21.1(preview)
1.19.11              1.20.5, 1.20.7
1.19.9               1.19.11, 1.20.5, 1.20.7
1.18.19              1.19.9, 1.19.11
1.18.17              1.18.19, 1.19.9, 1.19.11

```

bumped to a version that is supported