### PR TITLE
fix: update version stream repository instead of the terraform one

### DIFF
--- a/.jx/updatebot.yaml
+++ b/.jx/updatebot.yaml
@@ -3,9 +3,9 @@ kind: UpdateConfig
 spec:
   rules:
     - urls:
-        - https://github.com/jx3-gitops-repositories/jx3-terraform-azure
+        - https://github.com/jenkins-x/jx3-versions
       changes:
         - regex:
-            pattern: terraform-jx-azure\?ref=v(.*)"
+            pattern: version: (.*)
             files:
-              - "main.tf"
+              - "git/github.com/jenkins-x-terraform/terraform-jx-azure.yml"


### PR DESCRIPTION
Fixes https://github.com/jx3-gitops-repositories/jx3-terraform-azure/issues/24