### PR TITLE
Allow to set jenkins operator version via a terraform variable

### DIFF
--- a/terraform-jx-boot/boot.tf
+++ b/terraform-jx-boot/boot.tf
@@ -3,7 +3,7 @@ resource "helm_release" "jx-git-operator" {
   chart            = "jx-git-operator"
   namespace        = "jx-git-operator"
   repository       = "https://jenkins-x-charts.github.io/repo"
-  version          = "0.0.190"
+  version          = var.jx_git_operator_version
   create_namespace = true
 
   set {

--- a/variables.tf
+++ b/variables.tf
@@ -17,6 +17,12 @@ variable "jx_git_url" {
   description = "URL for the Jenkins X cluster git repository"
   type        = string
 }
+variable "jx_git_operator_version" {
+  description = "Version of the Jenkins Git Operator to install via the jx-operator chart"
+  type        = string
+  default     = "0.0.194"
+}
+
 variable "jx_bot_username" {
   description = "Bot username used to interact with the Jenkins X cluster git repository"
   type        = string


### PR DESCRIPTION
`0.0.190` has an old reference to a docker image that can't be pulled. THis has been fixed in the uptream chart here -> https://github.com/jenkins-x/jx-git-operator/commit/68a975b8093852074a7b20849d8b1d7fd83027bf

Having a variable instead of a hard coded value would be beneficial in any case. 

The dependent repo (https://github.com/jx3-gitops-repositories/jx3-terraform-azure) would need to be update to add this new variable to the module. 