### PR TITLE
chore: update aks and vault versions

### DIFF
--- a/terraform-jx-boot/vault.tf
+++ b/terraform-jx-boot/vault.tf
@@ -4,7 +4,7 @@ resource "helm_release" "vault-operator" {
   chart            = "vault-operator"
   namespace        = "jx-vault"
   repository       = "https://kubernetes-charts.banzaicloud.com"
-  version          = "1.10.0"
+  version          = "1.14.3"
   create_namespace = true
 }
 
@@ -14,6 +14,6 @@ resource "helm_release" "vault-instance" {
   chart      = "vault-instance"
   namespace  = "jx-vault"
   repository = "https://jenkins-x-charts.github.io/repo"
-  version    = "1.0.25"
+  version    = "1.0.24"
   depends_on = [helm_release.vault-operator]
 }

--- a/terraform-jx-cluster-aks/variables.tf
+++ b/terraform-jx-cluster-aks/variables.tf
@@ -96,7 +96,7 @@ variable "dns_prefix" {
 }
 variable "cluster_version" {
   type    = string
-  default = "1.20.7"
+  default = "1.21.7"
 }
 variable "location" {
   type    = string


### PR DESCRIPTION
* Updates the k8s version to 1.21.7 which is the version that is currently supported by jx-boot
* Updates vault version that supports the new k8s version