### PR TITLE
fix: bump azurerm provider version to fix issues with casing

### DIFF
--- a/terraform-jx-azurekeyvault/main.tf
+++ b/terraform-jx-azurekeyvault/main.tf
@@ -6,7 +6,7 @@ terraform {
   required_version = ">= 0.13.2"
   required_providers {
     azurerm = {
-      version = ">=2.41.0"
+      version = ">=2.48.0, <= 2.61.0"
     }
   }
 }
@@ -52,7 +52,7 @@ resource "azurerm_key_vault_access_policy" "jx" {
   secret_permissions = [
     "get",
     "set",
-    "delete",
+    "Delete",
   ]
 }
 
@@ -65,6 +65,6 @@ resource "azurerm_key_vault_access_policy" "terraform" {
   secret_permissions = [
     "get",
     "set",
-    "delete",
+    "Delete",
   ]
 }


### PR DESCRIPTION
Signed-off-by: ankitm123 <ankitmohapatra123@gmail.com>

slack thread: https://kubernetes.slack.com/archives/C9LTHT2BB/p1648308757268829

This issue was fixed in 2.48.0: https://github.com/hashicorp/terraform-provider-azurerm/pull/10593#issuecomment-781575449

Also these are the allowed values: https://registry.terraform.io/providers/hashicorp/azurerm/2.48.0/docs/resources/key_vault_access_policy#secret_permissions