### PR TITLE
feat: add CLIENT_ID to jx-boot-job-env-vars

### DIFF
--- a/local.tf
+++ b/local.tf
@@ -17,6 +17,7 @@ locals {
   job_secret_env_vars_vault = var.key_vault_enabled ? {
     AZURE_TENANT_ID       = module.secrets.tenant_id
     AZURE_SUBSCRIPTION_ID = module.secrets.subscription_id
+    AZURE_CLIENT_ID       = module.secrets.client_id
   } : {}
 
   job_secret_env_vars_ssa = var.server_side_apply_enabled ? {

--- a/main.tf
+++ b/main.tf
@@ -115,6 +115,7 @@ module "secrets" {
   source              = "./terraform-jx-azurekeyvault"
   enabled             = var.key_vault_enabled
   principal_id        = module.cluster.kubelet_identity_id
+  kubelet_client_id   = module.cluster.kubelet_client_id
   cluster_name        = local.cluster_name
   resource_group_name = var.key_vault_resource_group_name
   key_vault_name      = var.key_vault_name

--- a/terraform-jx-azurekeyvault/outputs.tf
+++ b/terraform-jx-azurekeyvault/outputs.tf
@@ -7,3 +7,6 @@ output "tenant_id" {
 output "subscription_id" {
   value = var.enabled ? data.azurerm_subscription.current.subscription_id : ""
 }
+output "client_id" {
+  value = var.enabled ? var.kubelet_client_id : ""
+}

--- a/terraform-jx-azurekeyvault/variables.tf
+++ b/terraform-jx-azurekeyvault/variables.tf
@@ -29,6 +29,10 @@ variable "principal_id" {
   type        = string
   description = "The id of the service principal that should be granted permission on the key vault"
 }
+variable "kubelet_client_id" {
+  type        = string
+  description = "The client id of the kubelet identity used when authenticating to the key vault"
+}
 variable "secret_map" {
   type        = map(string)
   description = "Map of secret keys and values to store in Azure Key Vault"


### PR DESCRIPTION
Adds `AZURE_CLIENT_ID` env var to `jx-boot-job-env-vars` to fix failing secret population when multiple managed identities are found on the kubelet.

Related PR https://github.com/jenkins-x-plugins/secretfacade/pull/20