### PR TITLE
fix: bump azurerm version to fix service principal access 

### DIFF
--- a/terraform-jx-azurekeyvault/main.tf
+++ b/terraform-jx-azurekeyvault/main.tf
@@ -6,7 +6,7 @@ terraform {
   required_version = ">= 0.13.2"
   required_providers {
     azurerm = {
-      version = ">=2.48.0, <= 2.61.0"
+      version = ">=2.48.0, <= 2.96.0"
     }
   }
 }

--- a/terraform-jx-boot/main.tf
+++ b/terraform-jx-boot/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.13.2"
   required_providers {
     helm = {
-      version = ">=2.0.1"
+      version = ">=2.0.1, < 3.0"
     }
   }
 }


### PR DESCRIPTION
### Description

Current Service Principal permission are insufficient for access to AKV and Vault AKS deployments. Increasing the Azure Resource Manager version to 2.96.0 resolves the issue.

### Which issue this PR fixes

https://github.com/jenkins-x-terraform/terraform-jx-azure/issues/56